### PR TITLE
LoggerのSD書き込みを実装（動作未確認）

### DIFF
--- a/src/components/Logger/logger.cpp
+++ b/src/components/Logger/logger.cpp
@@ -2,22 +2,129 @@
 
 namespace component {
 
-Logger::Logger(SPIClass& spi)
+Logger::Logger(SPIClass& spi, pin_t SD_cs, pin_t SD_inserted, float clock_freq)
   : process::Component("Logger", component_id),
-    spi_(spi) {
+    clock_(*this, clock_freq),
+    spi_(spi), SD_cs_(SD_cs), SD_inserted_(SD_inserted) {
 }
 
 void Logger::setup() {
-  listen(all_packets_, 8);
+  listen(all_packets_, WOBC_LOGGER_PACKET_QUEUE_SIZE);
 
-  // TODO SDカード初期化
+  pinMode(SD_inserted_, INPUT_PULLUP);
+  openFile();
 }
 
 void Logger::loop() {
-  while (all_packets_) {
-    const wcpp::Packet& packet = all_packets_.pop();
-    // TODO パケット書き込み
+  while (file_ && all_packets_) {
+    // パケット書き込み
+
+    const wcpp::Packet packet = all_packets_.pop();
+
+    uint8_t buf[wcpp::size_max];
+    wcpp::Packet packet_log = wcpp::Packet::empty(buf, wcpp::size_max);
+
+    if (packet.isLocal()) { // Add unit id
+      if (packet.isCommand()) {
+        packet_log.command(
+          packet.packet_id(), packet.component_id(), kernel::unit_id(), kernel::unit_id());
+      }
+      else {
+        packet_log.telemetry(
+          packet.packet_id(), packet.component_id(), kernel::unit_id(), kernel::unit_id());
+      }
+      packet_log.copyPayload(packet);
+    }
+    else {
+      packet_log.copy(packet);
+    }
+
+    packet_log.append("Ts").setInt(millis()); // Add timestamp in ms
+
+    bool ok = true;
+    ok |= file_.write(packet.encode(), packet.size()) == packet.size();
+    ok |= file_.write((uint8_t)packet.checksum()) == 1;
+    ok |= file_.write((uint8_t)'\0') == 1;
+
+    if (!ok) {
+      error("cWE", "SD log write error");
+      file_.close();
+    }
+    else {
+      packets_wrote_++;
+      bytes_wrote_ += packet_log.size() + 2;
+    }
   }
+}
+
+
+bool Logger::openFile() {
+  if (file_) {
+    return true;
+  }
+
+  if (digitalRead(SD_inserted_)) {
+      error("cNI", "SD card is not inserted");
+      return false;
+  }
+  if (!SD.begin(SD_cs_)) { 
+    error("cBF", "failed to initialize sd card");
+    return false;
+  }
+
+  unsigned file_number = 0;
+  wcpp::Packet card_info = loadPacket('c'); 
+  if (card_info) {
+    auto e = card_info.find("Fn");
+    if (e) file_number = (*e).getUInt();
+  }
+
+  char file_name[16];
+  snprintf(file_name, sizeof(file_name), "/log_%4d.bin", file_number);
+
+  file_ = SD.open(file_name, FILE_APPEND);
+
+  if (!file_) {
+    error("cOF", "failed to open file: %s", file_name);
+    SD.end();
+    return false;
+  }
+
+  file_number++;
+  wcpp::Packet card_info_updated = newPacket(32);
+  card_info_updated.telemetry('c', component_id);
+  card_info_updated.append("Fn").setInt(file_number);
+  storePacket(card_info_updated);
+
+  return true;
+}
+
+void Logger::flushFile() {
+  if (file_) file_.flush();
+}
+
+void Logger::sendLog() {
+  // Log
+  wcpp::Packet log = newPacket(32);
+  log.telemetry(log_telemetry_id, component_id);
+  log.append("Fo").setBool(!!file_);
+  log.append("Bw").setInt(bytes_wrote_);
+  log.append("Pw").setInt(packets_wrote_);
+  sendPacket(log);
+}
+
+Logger::Clock::Clock(Logger& logger, float freq)
+  : process::Timer("LoggerClock", 1000 / freq),
+    logger_(logger) {
+}
+
+void Logger::Clock::callback() { 
+  if (!logger_.file_) {
+    logger_.openFile();
+  }
+
+  logger_.sendLog();
+  logger_.flushFile();
 }
 
 }

--- a/src/components/Logger/logger.h
+++ b/src/components/Logger/logger.h
@@ -1,22 +1,52 @@
 #pragma once
 #include <library/wobc.h>
 #include <SPI.h>
+#include <SD.h>
 
 namespace component {
 
+#ifndef WOBC_LOGGER_PACKET_QUEUE_SIZE
+#define WOBC_LOGGER_PACKET_QUEUE_SIZE 32
+#endif
+
 class Logger: public process::Component {
 public:
-  static const uint8_t component_id = 0x20; // TODO
+  static const uint8_t component_id = 20; // TODO
+  static const uint8_t log_telemetry_id = 'L';
 
-  Logger(SPIClass& spi);
+  Logger(SPIClass& spi, pin_t SD_cs, pin_t SD_inserted = no_pin, float clock_freq = 1.0);
 
 protected:
+
+  class Clock: public process::Timer { // ログ出力等のタイマー
+  public:
+    Clock(Logger& logger, float freq);
+
+  protected:
+    Logger& logger_;
+
+    void callback() override;
+  } clock_;
+
   SPIClass& spi_;
+  pin_t SD_inserted_;
+  pin_t SD_cs_;
+
+  File file_;
 
   Listener all_packets_;
 
+  unsigned packets_wrote_;
+  unsigned bytes_wrote_;
+
   void setup() override;
   void loop() override;
+
+  bool openFile();
+  void sendLog();
+  void flushFile();
+
+  friend Clock;
 };
 
 }

--- a/src/library/common.h
+++ b/src/library/common.h
@@ -11,6 +11,8 @@
 
 using pin_t = byte;
 
+constexpr pin_t no_pin = 255;
+
 constexpr uint8_t packet_id_error = '!';
 constexpr uint8_t packet_id_heartbeat = '"';
 constexpr uint8_t packet_id_log = '#';

--- a/src/modules/GS/main.cpp
+++ b/src/modules/GS/main.cpp
@@ -9,6 +9,12 @@
 constexpr uint8_t module_id = 0xF0; // TBD
 constexpr uint8_t unit_id = 0x01; // TBD
 
+#define SD_SCK_PIN 1
+#define SD_MOSI_PIN 4
+#define SD_MISO_PIN 3
+#define SD_CS_PIN 2
+#define SD_INSERTED_PIN 5
+
 // Core
 core::CANBus can_bus(44, 43);
 core::SerialBus serial_bus(Serial);
@@ -16,8 +22,8 @@ interface::WatchIndicator<unsigned> status_indicator(42, kernel::packetCount());
 interface::WatchIndicator<unsigned> error_indicator(41, kernel::errorCount());
 
 // Components
-component::Logger logger(SPI);
-component::LoRa lora(Serial1, 0, 0, 0); // TBD
+component::Logger logger(SPI, SD_CS_PIN, SD_INSERTED_PIN);
+// component::LoRa lora(Serial1, 0, 0, 0); // TBD
 component::LiPoPowerSimple power(Wire);
 component::Pressure pressure(Wire);
 
@@ -42,6 +48,8 @@ void setup() {
   Serial.begin(115200);
   Serial0.setPins(2, 1);
 
+  SPI.begin(SD_SCK_PIN, SD_MISO_PIN, SD_MOSI_PIN, SD_CS_PIN);
+
   kernel::setUnitId(unit_id); // unit id を設定（mainモジュールのみ）
   if (!kernel::begin(module_id, true)) return; // check module id
 
@@ -59,7 +67,7 @@ void setup() {
   delay(1000);
 
   logger.begin();
-  lora.begin();
+  // lora.begin();
   power.begin();
   pressure.begin();
   main_.begin();


### PR DESCRIPTION
@KeisukeSuganuma 

LoggerコンポーネントのSD書き込み部分を書いたから，動くことを確認してマージしてほしい

SDカードの中身は
```
$ wcpp-util -f log_XXXX.bin
```
で確認できるはず